### PR TITLE
Fixing lib64/lib confusion.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,7 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DCMAKE_INSTALL_LIBDIR=lib \
     -S "${SRC_DIR}/src/fortran" \
     -B .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,7 @@ requirements:
 
 test:
   commands:
-    - test -f "${PREFIX}/lib${ARCH}/libbezier${SHLIB_EXT}"  # [linux]
-    - test -f "${PREFIX}/lib/libbezier${SHLIB_EXT}"         # [osx]
+    - test -f "${PREFIX}/lib/libbezier${SHLIB_EXT}"         # [linux or osx]
     - if not exist %LIBRARY_BIN%\\bezier%SHLIB_EXT% exit 1  # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ tar_gz_hash }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
The convention is relevant on the build OS (CentOS) but not in `comda`.

See: https://github.com/conda/conda-build/issues/244

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
